### PR TITLE
Add missing comment indicators in component CMakeLists file

### DIFF
--- a/extras/for building with ESP_IDF/optional when using as component/CMakeLists.txt
+++ b/extras/for building with ESP_IDF/optional when using as component/CMakeLists.txt
@@ -30,5 +30,6 @@ set(COMPONENT_ADD_INCLUDEDIRS
 register_component()
 
 # PS: it is also possible to install CleanRTOS as a normal, "non-component" library.
-  In that case, don't use this CMakeLists file, but follow the instructions in the
-  CMakeLists file in the "content for root folder" instead.
+# In that case, don't use this CMakeLists file, but follow the instructions in the
+# CMakeLists file in the "content for root folder" instead.
+


### PR DESCRIPTION
This pull request adds missing comment indicators (#) in the CMakeLists file located in `extras/for building with ESP_IDF/optional when using as component`. The absence of these indicators lead to compiler issues, as the comments were being misinterpreted as code.